### PR TITLE
Use gradle.org in urlRoot because codehaus.org is no more

### DIFF
--- a/wrapper/gradle-wrapper.properties
+++ b/wrapper/gradle-wrapper.properties
@@ -4,6 +4,6 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 distributionVersion=0.9-rc-3
 zipStorePath=wrapper/dists
-urlRoot=http\://dist.codehaus.org/gradle
+urlRoot=https\://services.gradle.org/distributions/
 distributionName=gradle
 distributionClassifier=bin


### PR DESCRIPTION
Build fails because codehaus.org is down for good. Use gradle.org instead.